### PR TITLE
Fixed incorrect redirect on Introduction page

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -21,7 +21,7 @@ Play Hosting has full support for a huge library of plugins and modpacks, meanin
   <Card title="Joining the queue" icon="clock" href="/minecraft/queue">
     Find out about our queue system
   </Card>
-  <Card title="Using the console" icon="terminal" href="/minecraft/queue">
+  <Card title="Using the console" icon="terminal" href="/minecraft/console">
     Manage your server with the console
   </Card>
   <Card title="Discord" icon="discord" href="https://play.hosting/discord">


### PR DESCRIPTION
Clicking the "Using the console" card used to redirect you to the Queue page, it now redirects you to the correct location